### PR TITLE
Fix build and add SystemCore build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,9 +6,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
-env:
-  SCCACHE_WEBDAV_ENDPOINT: "https://frcmaven.wpi.edu/artifactory/wpilib-generic-cache-cmake"
-
 jobs:
   build-docker:
     strategy:
@@ -17,16 +14,19 @@ jobs:
         include:
           - container: wpilib/roborio-cross-ubuntu:2025-22.04
             artifact-name: Athena
-            build-options: -Pplatform=linux-athena -Psccache -Ptoolchain=/usr/local/toolchain-config.cmake
+            build-options: -Pplatform=linux-athena -Ptoolchain=/usr/local/toolchain-config.cmake
+          - container: wpilib/systemcore-cross-ubuntu:2025-22.04
+            artifact-name: SystemCore
+            build-options: -Pplatform=linux-systemcore -Ptoolchain=/usr/local/toolchain-config.cmake
           - container: wpilib/raspbian-cross-ubuntu:bookworm-22.04
             artifact-name: Arm32
-            build-options: -Pplatform=linux-arm32 -Psccache -Ptoolchain=/usr/local/toolchain-config.cmake
+            build-options: -Pplatform=linux-arm32 -Ptoolchain=/usr/local/toolchain-config.cmake
           - container: wpilib/aarch64-cross-ubuntu:bookworm-22.04
             artifact-name: Arm64
-            build-options: -Pplatform=linux-arm64 -Psccache -Ptoolchain=/usr/local/toolchain-config.cmake
+            build-options: -Pplatform=linux-arm64 -Ptoolchain=/usr/local/toolchain-config.cmake
           - container: wpilib/ubuntu-base:22.04
             artifact-name: Linux
-            build-options: -Pplatform=linux-x86_64 -Psccache
+            build-options: -Pplatform=linux-x86_64
 
     name: "Build - ${{ matrix.artifact-name }}"
     runs-on: ubuntu-latest
@@ -41,8 +41,6 @@ jobs:
         run: |
           sudo apt-get update -q
           sudo apt-get install -y ninja-build build-essential libtbb-dev
-      - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.5
       - name: Build with Gradle
         run: ./gradlew publish ${{ matrix.build-options }}
         env:
@@ -60,10 +58,10 @@ jobs:
         include:
           - artifact-name: WinArm64
             tool-arch: amd64_arm64
-            build-options: -Pplatform=windows-arm64 -Psccache
+            build-options: -Pplatform=windows-arm64
           - artifact-name: Win64
             tool-arch: amd64
-            build-options: -Pplatform=windows-x86_64 -Psccache
+            build-options: -Pplatform=windows-x86_64
 
     name: "Build - ${{ matrix.artifact-name }}"
     runs-on: windows-2019
@@ -78,8 +76,6 @@ jobs:
       - uses: ilammy/msvc-dev-cmd@v1.13.0
         with:
           arch: ${{ matrix.tool-arch }}
-      - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.5
       - name: Build with Gradle
         run: ./gradlew publish ${{ matrix.build-options }}
         env:
@@ -103,10 +99,8 @@ jobs:
           distribution: 'temurin'
       - run: brew install cmake ninja
         name: install ninja
-      - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.5
       - name: Build with Gradle
-        run: ./gradlew publish -Pplatform=osx-universal -Psccache
+        run: ./gradlew publish -Pplatform=osx-universal
         env:
           SCCACHE_WEBDAV_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           SCCACHE_WEBDAV_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,10 +31,10 @@ set(GTSAM_BUILD_PYTHON OFF)
 set(GTSAM_BUILD_EXAMPLES_ALWAYS OFF)
 set(GTSAM_BUILD_TESTS OFF)
 set(BUILD_SHARED_LIBS OFF)
-set(GTSAM_FORCE_SHARED_LIB OFF)
-set(GTSAM_FORCE_STATIC_LIB ON)
 set(GTSAM_USE_SYSTEM_EIGEN ON)
-
+if(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-use-after-free")
+endif()
 fetchcontent_declare(
     gtsam
     GIT_REPOSITORY    https://github.com/borglab/gtsam

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,8 @@ def getPlatform() {
 def getPlatformPath(platform) {
     if (platform == "linux-athena") {
         return "linux/athena"
+    } else if (platform == "linux-systemcore") {
+        return "linux/systemcore"
     } else if (platform == "linux-arm32") {
         return "linux/arm32"
     } else if (platform == "linux-arm64") {


### PR DESCRIPTION
Suppresses a use-after-free warning that only shows up on the ARM compilers. Also removes sccache because builds are infrequent enough where caching isn't helpful and removes some unnecessary CMake options related to building statically.